### PR TITLE
fix: Overview card formatting 

### DIFF
--- a/plugins/daytona/src/components/WorkspaceOverviewContent/CustomWorkspaceOverviewTable.tsx
+++ b/plugins/daytona/src/components/WorkspaceOverviewContent/CustomWorkspaceOverviewTable.tsx
@@ -25,7 +25,7 @@ const columns: TableColumn[] = [
         title: 'Open',
         field: 'Open',
         width: 'auto',
-        cellStyle: { whiteSpace: 'nowrap' },
+        cellStyle: { whiteSpace: 'nowrap', textAlign: 'end', paddingRight: '20px' },
         render: (row: Partial<CustomWorkspace>) => getWorkspaceOpenButton({
             name: row.workspace?.id,
             domain: row.domain,

--- a/plugins/daytona/src/utils/createWorkspaceInfo.tsx
+++ b/plugins/daytona/src/utils/createWorkspaceInfo.tsx
@@ -20,7 +20,7 @@ export const createWorkspaceInfo = (props: {
     status?: State;
 }) => {
   const { name, branch, ahead, behind, status } = props;
-  const aheadBehind = getGitStatus({ahead, behind});
+  const branchDiff = getGitStatus({branch, ahead, behind});
   const statusIndicator = getWorkspaceState({status});
   
   return (
@@ -31,8 +31,7 @@ export const createWorkspaceInfo = (props: {
           <div style={{padding: '1%', fontSize: '1vw'}}>{name}</div>
           <span style={{display: 'flex', fontSize: '0.8vw', marginTop: '1%', marginLeft: 'auto'}}>
             <div style={{padding: '1%', margin: '1%'}}>{statusIndicator}</div>
-            <div style={{padding: '1%', margin: '1%'}}>{branch}</div>
-            <div style={{padding: '1%', margin: '1%'}}>{aheadBehind}</div>
+            <div style={{padding: '1%', margin: '1%'}}>{branchDiff}</div>
           </span>
         </Box>
       </div>

--- a/plugins/daytona/src/utils/createWorkspaceInfo.tsx
+++ b/plugins/daytona/src/utils/createWorkspaceInfo.tsx
@@ -53,6 +53,7 @@ export const getWorkspaceOpenButton = (props: {
     }
 
     return (
+      <div>
         <Tooltip placement="top" arrow title="Open">
           <Button
             variant="outlined"
@@ -63,6 +64,7 @@ export const getWorkspaceOpenButton = (props: {
             Open
           </Button>
         </Tooltip>
+      </div>
     );
 }
 

--- a/plugins/daytona/src/utils/createWorkspaceInfo.tsx
+++ b/plugins/daytona/src/utils/createWorkspaceInfo.tsx
@@ -28,8 +28,8 @@ export const createWorkspaceInfo = (props: {
       {/* <div style={{padding: '1%', fontSize: '0.9vw',}}>{team}</div> */}
       <div>
         <Box alignItems="center">
-          {name}
-          <span style={{display: 'flex', fontSize: '0.4vw', font: 'caption', marginTop: '1%', marginLeft: 'auto'}}>
+          <div style={{padding: '1%', fontSize: '1vw'}}>{name}</div>
+          <span style={{display: 'flex', fontSize: '0.8vw', marginTop: '1%', marginLeft: 'auto'}}>
             <div style={{padding: '1%', margin: '1%'}}>{statusIndicator}</div>
             <div style={{padding: '1%', margin: '1%'}}>{branch}</div>
             <div style={{padding: '1%', margin: '1%'}}>{aheadBehind}</div>
@@ -53,18 +53,18 @@ export const getWorkspaceOpenButton = (props: {
     }
 
     return (
-      <div>
-        <Tooltip placement="top" arrow title="Open">
-          <Button
-            variant="outlined"
-            color="primary"
-            // Calling getAccessToken instead of a plain signIn because we are going to get the correct scopes right away. No need to second request
-            onClick={() => openInNewTab(`${openUrl}`)}
-          >
-            Open
-          </Button>
-        </Tooltip>
-      </div>
+        <div>
+          <Tooltip placement="top" arrow title="Open">
+            <Button
+              variant="outlined"
+              color="primary"
+              // Calling getAccessToken instead of a plain signIn because we are going to get the correct scopes right away. No need to second request
+              onClick={() => openInNewTab(`${openUrl}`)}
+            >
+              Open
+            </Button>
+          </Tooltip>
+        </div>
     );
 }
 

--- a/plugins/daytona/src/utils/getGitStatus.tsx
+++ b/plugins/daytona/src/utils/getGitStatus.tsx
@@ -7,10 +7,11 @@ import React from "react";
  * @returns a React JSX element with Commit Status in the format ahead/behind
  */
 export const getGitStatus = (props: {
+    branch?: string;
     ahead?: number;
     behind?: number;
 }) => {
-  if(props.ahead === undefined || props.behind === undefined) return null;
+  if(props.branch === undefined || props.ahead === undefined || props.behind === undefined) return null;
   return (
     <>
       {getGitStatusView(props)}
@@ -27,13 +28,15 @@ export const getGitStatus = (props: {
 * @returns the value with Commit Status in the format ahead/behind
 */
 export function getGitStatusView({
+  branch,
   ahead,
   behind
 }: {
+  branch?: string;
   ahead?: number;
   behind?: number;
 }) {
-  if (ahead === undefined || behind === undefined) return null;
-  const answer = `${ahead}/${behind}`;
+  if (branch === undefined || ahead === undefined || behind === undefined) return null;
+  const answer = `(${branch} ${ahead}/${behind})`;
   return answer;
 }


### PR DESCRIPTION
Fixes the below formatting for Component `OverviewCard`

- Increases the font of the workspace name
- Reduces the font of the workspace details
- Adds a bracket around git details if the branch exists
- Aligns the `OpenButton` to the right for matching left and right margins